### PR TITLE
onIframeLoad function was not getting called 

### DIFF
--- a/src/Jitsi.tsx
+++ b/src/Jitsi.tsx
@@ -41,7 +41,7 @@ const Jitsi: React.FC<Props> = (props: Props) => {
                 interfaceConfigOverwrite: interfaceConfig,
                 noSSL,
                 jwt,
-                onLoad: onIframeLoad,
+                onload: onIframeLoad,
                 devices,
                 userInfo,
             }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -30,7 +30,7 @@ export interface JitsiMeetAPIOptions {
 
     jwt?: string;
 
-    onLoad?: () => void;
+    onload?: () => void;
 
     invites?: {};
 


### PR DESCRIPTION
due to typo in option name to JitsiMeetExternalAPI 
changed onLoad to onload

P.S. onload doesn't support arrow functions,  need to use function when passing to onload.